### PR TITLE
Removed contrib.auth from TEST_NON_SERIALIZED_APPS.

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -35,5 +35,3 @@ SITE_ID = 1
 
 MEDIA_ROOT = 'media'
 STATIC_ROOT = 'static'
-
-TEST_NON_SERIALIZED_APPS = ['django.contrib.auth']


### PR DESCRIPTION
I expect the Travis build to fail until I submit a fix in Django.
