### PR TITLE
Handle case where reset attempts to access deleted session data

### DIFF
--- a/formtools/wizard/storage/session.py
+++ b/formtools/wizard/storage/session.py
@@ -17,3 +17,13 @@ class SessionStorage(BaseStorage):
         self.request.session.modified = True
 
     data = property(_get_data, _set_data)
+
+    def reset(self):
+        # Handle the possibility that the session data has already been
+        # deleted by the Django application (e.g. an explicit session flush,
+        # or django.contrib.auth.logout()), in which case there is no
+        # need to delete any session data.
+        try:
+            super(SessionStorage, self).reset()
+        except KeyError:  # KeyError: session data already deleted.
+            self.init_data()

--- a/tests/wizard/test_sessionstorage.py
+++ b/tests/wizard/test_sessionstorage.py
@@ -2,9 +2,15 @@ from django.test import TestCase
 
 from formtools.wizard.storage.session import SessionStorage
 
-from .storage import TestStorage
+from .storage import TestStorage, get_request
 
 
 class TestSessionStorage(TestStorage, TestCase):
     def get_storage(self):
         return SessionStorage
+
+    def test_reset_when_session_data_is_already_deleted(self):
+        request = get_request()
+        storage = self.get_storage()('wizard1', request)
+        request.session.flush()
+        storage.reset()


### PR DESCRIPTION
Fixes #103

Form wizards can fail with an uncaught `KeyError` if the session is flushed in the `done` method (e.g. using `request.session.flush()`, or `django.contrib.auth.logout()`). A `KeyError` occurs because django-formtools deletes the data it stores in the session by first accessing them(!) ([reference](https://github.com/django/django-formtools/blob/9c8ea543c81b26c6c8c63ce1fda6480ab0b79e83/formtools/wizard/storage/base.py#L33-L36))

- [x] Unit tests

