### PR TITLE
Convert dict_values object to list

### DIFF
--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -355,7 +355,7 @@ class WizardView(TemplateView):
         # render the done view and reset the wizard before returning the
         # response. This is needed to prevent from rendering done with the
         # same data twice.
-        done_response = self.done(final_forms.values(), form_dict=final_forms, **kwargs)
+        done_response = self.done(list(final_forms.values()), form_dict=final_forms, **kwargs)
         self.storage.reset()
         return done_response
 


### PR DESCRIPTION
According to the docs (https://django-formtools.readthedocs.io/en/latest/wizard.html#formtools.wizard.views.WizardView.done) `WizardView.done` is supposed to be called with a `list`, in python 3 `dict.values()` returns a `dict_values` object which is missing some of the properties lists have.

After upgrading a project of ours we were encountering `TypeError: 'dict_values' object does not support indexing` errors because our implementation of `done` was accessing forms by index.