### PR TITLE
Fixed #161 - Mentioned clearly that django-formtools is Python 3 only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,3 @@ not_skip = __init__.py
 
 [metadata]
 license-file = LICENSE
-
-[wheel]
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Thanks Sebastian Weigand for the report.