### PR TITLE
Addition to PR #162

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     package_data=find_package_data(),
     install_requires=['Django>=1.11'],
+    python_requires=">=3.4",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
Yesterday, in the heat of the moment, I forgot the actual important part for the python 3 only release, sorry for that it was late :cold_sweat:
The `kwarg` in `setup` that tells PyPi, which python versions a package supports is [`python_requires`](https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires), just for future reference, when you are going to deprecate the py34 support.