### PR TITLE
url() to path() and re_path()

### DIFF
--- a/docs/preview.rst
+++ b/docs/preview.rst
@@ -84,7 +84,7 @@ How to use ``FormPreview``
 
    ...and add the following line to the appropriate model in your URLconf::
 
-       url(r'^post/$', SomeModelFormPreview(SomeModelForm)),
+       path('post/', SomeModelFormPreview(SomeModelForm)),
 
    where ``SomeModelForm`` is a Form or ModelForm class for the model.
 

--- a/docs/wizard.rst
+++ b/docs/wizard.rst
@@ -250,13 +250,13 @@ deploy the new :class:`WizardView` object at a URL in the ``urls.py``. The
 wizard's ``as_view()`` method takes a list of your
 :class:`~django.forms.Form` classes as an argument during instantiation::
 
-    from django.conf.urls import url
+    from django.path import path
 
     from myapp.forms import ContactForm1, ContactForm2
     from myapp.views import ContactWizard
 
     urlpatterns = [
-        url(r'^contact/$', ContactWizard.as_view([ContactForm1, ContactForm2])),
+        path('contact/', ContactWizard.as_view([ContactForm1, ContactForm2])),
     ]
 
 You can also pass the form list as a class attribute named ``form_list``::
@@ -311,7 +311,7 @@ Here's what the view code might look like::
 The ``urls.py`` file would contain something like::
 
     urlpatterns = [
-        url(r'^checkout/$', OrderWizard.as_view(FORMS, condition_dict={'cc': pay_by_credit_card})),
+        path('checkout/', OrderWizard.as_view(FORMS, condition_dict={'cc': pay_by_credit_card})),
     ]
 
 The ``condition_dict`` can be passed as attribute for the ``as_view()``
@@ -681,7 +681,7 @@ We define our wizard in a ``views.py``::
 
 We need to add the ``ContactWizard`` to our ``urls.py`` file::
 
-    from django.conf.urls import url
+    from django.urls import path
 
     from myapp.forms import ContactForm1, ContactForm2
     from myapp.views import ContactWizard, show_message_form_condition
@@ -689,7 +689,7 @@ We need to add the ``ContactWizard`` to our ``urls.py`` file::
     contact_forms = [ContactForm1, ContactForm2]
 
     urlpatterns = [
-        url(r'^contact/$', ContactWizard.as_view(contact_forms,
+        path('contact/', ContactWizard.as_view(contact_forms,
             condition_dict={'1': show_message_form_condition}
         )),
     ]
@@ -734,7 +734,7 @@ The :meth:`~WizardView.as_view` method takes two additional arguments:
 This is an example of a ``urls.py`` for a contact wizard with two steps, step 1 named
 ``contactdata`` and step 2 named ``leavemessage``::
 
-    from django.conf.urls import url
+    from django.urls import path, re_path
 
     from myapp.forms import ContactForm1, ContactForm2
     from myapp.views import ContactWizard
@@ -748,8 +748,8 @@ This is an example of a ``urls.py`` for a contact wizard with two steps, step 1 
         url_name='contact_step', done_step_name='finished')
 
     urlpatterns = [
-        url(r'^contact/(?P<step>.+)/$', contact_wizard, name='contact_step'),
-        url(r'^contact/$', contact_wizard, name='contact'),
+        re_path(r'^contact/(?P<step>.+)/$', contact_wizard, name='contact_step'),
+        path('contact/', contact_wizard, name='contact'),
     ]
 
 Advanced ``NamedUrlWizardView`` methods

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -2,11 +2,11 @@
 This is a URLconf to be loaded by tests.py. Add any URLs needed for tests only.
 """
 
-from django.conf.urls import url
+from django.urls import path
 
 from .forms import TestForm
 from .tests import TestFormPreview
 
 urlpatterns = [
-    url(r'^preview/', TestFormPreview(TestForm)),
+    path('preview/', TestFormPreview(TestForm)),
 ]

--- a/tests/wizard/namedwizardtests/urls.py
+++ b/tests/wizard/namedwizardtests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from .forms import (
     CookieContactWizard, Page1, Page2, Page3, Page4, SessionContactWizard,
@@ -22,8 +22,8 @@ def get_named_cookie_wizard():
 
 
 urlpatterns = [
-    url(r'^nwiz_session/(?P<step>.+)/$', get_named_session_wizard(), name='nwiz_session'),
-    url(r'^nwiz_session/$', get_named_session_wizard(), name='nwiz_session_start'),
-    url(r'^nwiz_cookie/(?P<step>.+)/$', get_named_cookie_wizard(), name='nwiz_cookie'),
-    url(r'^nwiz_cookie/$', get_named_cookie_wizard(), name='nwiz_cookie_start'),
+    re_path(r'^nwiz_session/(?P<step>.+)/$', get_named_session_wizard(), name='nwiz_session'),
+    path('nwiz_session/', get_named_session_wizard(), name='nwiz_session_start'),
+    re_path(r'nwiz_cookie/(?P<step>.+)/$', get_named_cookie_wizard(), name='nwiz_cookie'),
+    path('nwiz_cookie/', get_named_cookie_wizard(), name='nwiz_cookie_start'),
 ]

--- a/tests/wizard/wizardtests/urls.py
+++ b/tests/wizard/wizardtests/urls.py
@@ -1,21 +1,21 @@
-from django.conf.urls import url
+from django.urls import path
 
 from .forms import (
     CookieContactWizard, Page1, Page2, Page3, Page4, SessionContactWizard,
 )
 
 urlpatterns = [
-    url(r'^wiz_session/$', SessionContactWizard.as_view(
+    path('wiz_session/', SessionContactWizard.as_view(
         [('form1', Page1),
          ('form2', Page2),
          ('form3', Page3),
          ('form4', Page4)])),
-    url(r'^wiz_cookie/$', CookieContactWizard.as_view(
+    path('wiz_cookie/', CookieContactWizard.as_view(
         [('form1', Page1),
          ('form2', Page2),
          ('form3', Page3),
          ('form4', Page4)])),
-    url(r'^wiz_other_template/$', CookieContactWizard.as_view(
+    path('wiz_other_template/', CookieContactWizard.as_view(
         [('form1', Page1),
          ('form2', Page2),
          ('form3', Page3),


### PR DESCRIPTION
url() is deprecated in Django 3.1. path() and re_path() are available in all suppored django versions.