### PR TITLE
@smithdc1 Removed default default_app_config setting for Django>=3.2 

### DIFF
--- a/formtools/__init__.py
+++ b/formtools/__init__.py
@@ -1,3 +1,6 @@
+import django
+
 __version__ = '2.2'
 
-default_app_config = 'formtools.apps.FormToolsConfig'
+if django.VERSION <= (3, 2):
+    default_app_config = 'formtools.apps.FormToolsConfig'


### PR DESCRIPTION
deault_app_config will be deprecated in Django 3.2.