### PR TITLE
updated django-admin entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docs:
 test:
 	@flake8
 	@isort --check-only --diff formtools tests
-	@ coverage run `which django-admin.py` test tests
+	@ coverage run `which django-admin` test tests
 	@coverage report
 
 .PHONY: clean docs test maketranslations pulltranslations compiletranslations

--- a/formtools/__init__.py
+++ b/formtools/__init__.py
@@ -1,3 +1,6 @@
+import django
+
 __version__ = '2.2'
 
-default_app_config = 'formtools.apps.FormToolsConfig'
+if django.VERSION <= (3, 2):
+    default_app_config = 'formtools.apps.FormToolsConfig'


### PR DESCRIPTION
django-admin.py is deprecated in Django 3.1. Used django-admin instead.