### PR TITLE
Updated django-admin entrypoint in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docs:
 test:
 	@flake8
 	@isort --check-only --diff formtools tests
-	@ coverage run `which django-admin.py` test tests
+	@ coverage run `which django-admin` test tests
 	@coverage report
 
 .PHONY: clean docs test maketranslations pulltranslations compiletranslations


### PR DESCRIPTION
django-admin.py is deprecated in Django 3.1. Used django-admin instead.

I managed to make a right mess of the commit history at #182. (Even a force push wouldn't override what I needed). Sorry for the noise. 