### PR TITLE
Refs #23 - Initialized preview form with files.

### DIFF
--- a/formtools/preview.py
+++ b/formtools/preview.py
@@ -59,7 +59,9 @@ class FormPreview:
         Validates the POST data. If valid, displays the preview page.
         Else, redisplays form.
         """
-        f = self.form(request.POST, auto_id=self.get_auto_id())
+        # Even if files are not supported in preview, we still initialize files
+        # to give a chance to process_preview to access files content.
+        f = self.form(data=request.POST, files=request.FILES, auto_id=self.get_auto_id())
         context = self.get_context(request, f)
         if f.is_valid():
             self.process_preview(request, f, context)

--- a/formtools/utils.py
+++ b/formtools/utils.py
@@ -1,5 +1,6 @@
 import pickle
 
+from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.utils.crypto import salted_hmac
 
 
@@ -17,6 +18,8 @@ def form_hmac(form):
             value = bf.field.clean(bf.data) or ''
         if isinstance(value, str):
             value = value.strip()
+        elif isinstance(value, TemporaryUploadedFile):
+            value = value.read()
         data.append((bf.name, value))
 
     pickled = pickle.dumps(data, pickle.HIGHEST_PROTOCOL)

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -16,3 +16,8 @@ class HashTestForm(forms.Form):
 class HashTestBlankForm(forms.Form):
     name = forms.CharField(required=False)
     bio = forms.CharField(required=False)
+
+
+class HashTestFormWithFile(forms.Form):
+    name = forms.CharField()
+    attachment = forms.FileField(required=False)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,13 +2,19 @@ import datetime
 import os
 import unittest
 import warnings
+from io import StringIO
 
 from django import http
+from django.core.files.uploadedfile import (
+    InMemoryUploadedFile, TemporaryUploadedFile,
+)
 from django.test import TestCase, override_settings
 
 from formtools import preview, utils
 
-from .forms import HashTestBlankForm, HashTestForm, TestForm
+from .forms import (
+    HashTestBlankForm, HashTestForm, HashTestFormWithFile, TestForm,
+)
 
 success_string = "Done was called!"
 success_string_encoded = success_string.encode()
@@ -191,3 +197,20 @@ class FormHmacTests(unittest.TestCase):
         hash1 = utils.form_hmac(f1)
         hash2 = utils.form_hmac(f2)
         self.assertEqual(hash1, hash2)
+
+    def test_hash_with_file(self):
+        with InMemoryUploadedFile(StringIO('1'), '', 'test', 'text/plain', 1, 'utf8') as some_file:
+            f1 = HashTestFormWithFile({'name': 'joe'})
+            f2 = HashTestFormWithFile({'name': 'joe'}, files={'attachment': some_file})
+            hash1 = utils.form_hmac(f1)
+            hash2 = utils.form_hmac(f2)
+        self.assertNotEqual(hash1, hash2)
+
+        with TemporaryUploadedFile('test', 'text/plain', 1, 'utf8') as some_file:
+            some_file.write(b'1')
+            some_file.seek(0)
+            f1 = HashTestFormWithFile({'name': 'joe'})
+            f2 = HashTestFormWithFile({'name': 'joe'}, files={'attachment': some_file})
+            hash1 = utils.form_hmac(f1)
+            hash2 = utils.form_hmac(f2)
+        self.assertNotEqual(hash1, hash2)


### PR DESCRIPTION
Even if file uploads are not supported in preview, we properly initialize
forms with both data and files. In certain use cases, custom process_preview()
implementations may access uploaded file data.