### PR TITLE
Get form list

### DIFF
--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -406,7 +406,7 @@ class WizardView(TemplateView):
         """
         if step is None:
             step = self.steps.current
-        form_class = self.form_list[step]
+        form_class = self.get_form_list()[step]
         # prepare the kwargs for the form instance.
         kwargs = self.get_form_kwargs(step)
         kwargs.update({

--- a/tests/wizard/test_forms.py
+++ b/tests/wizard/test_forms.py
@@ -91,6 +91,14 @@ class TestWizardWithTypeCheck(TestWizard):
         return http.HttpResponse("All good")
 
 
+class TestWizardWithCustomGetFormList(TestWizard):
+
+    form_list = [Step1]
+
+    def get_form_list(self):
+        return {'start': Step1, 'step2': Step2}
+
+
 class FormTests(TestCase):
     def test_form_init(self):
         testform = TestWizard.get_initkwargs([Step1, Step2])
@@ -256,6 +264,25 @@ class FormTests(TestCase):
         testform = TestWizardWithTypeCheck.as_view([('start', Step1)])
         response, instance = testform(request)
         self.assertEqual(response.status_code, 200)
+
+    def test_get_form_list_default(self):
+        request = get_request()
+        testform = TestWizard.as_view([('start', Step1)])
+        response, instance = testform(request)
+
+        form_list = instance.get_form_list()
+        self.assertEqual(form_list, {'start': Step1})
+        with self.assertRaises(KeyError):
+            instance.get_form('step2')
+
+    def test_get_form_list_custom(self):
+        request = get_request()
+        testform = TestWizardWithCustomGetFormList.as_view([('start', Step1)])
+        response, instance = testform(request)
+
+        form_list = instance.get_form_list()
+        self.assertEqual(form_list, {'start': Step1, 'step2': Step2})
+        self.assertIsInstance(instance.get_form('step2'), Step2)
 
 
 class SessionFormTests(TestCase):


### PR DESCRIPTION
Allow users to customise get_form_list by ensuring it is used everywhere.

This cherry picks the commit from this PR (to preserve attribution)
https://github.com/jazzband/django-formtools/pull/62

And adds a regression test.