### PR TITLE
Fixing #220 (by reverting the breaking change)

### DIFF
--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -406,7 +406,7 @@ class WizardView(TemplateView):
         """
         if step is None:
             step = self.steps.current
-        form_class = self.get_form_list()[step]
+        form_class = self.form_list[step]
         # prepare the kwargs for the form instance.
         kwargs = self.get_form_kwargs(step)
         kwargs.update({

--- a/tests/wizard/test_forms.py
+++ b/tests/wizard/test_forms.py
@@ -91,14 +91,6 @@ class TestWizardWithTypeCheck(TestWizard):
         return http.HttpResponse("All good")
 
 
-class TestWizardWithCustomGetFormList(TestWizard):
-
-    form_list = [Step1]
-
-    def get_form_list(self):
-        return {'start': Step1, 'step2': Step2}
-
-
 class FormTests(TestCase):
     def test_form_init(self):
         testform = TestWizard.get_initkwargs([Step1, Step2])
@@ -264,25 +256,6 @@ class FormTests(TestCase):
         testform = TestWizardWithTypeCheck.as_view([('start', Step1)])
         response, instance = testform(request)
         self.assertEqual(response.status_code, 200)
-
-    def test_get_form_list_default(self):
-        request = get_request()
-        testform = TestWizard.as_view([('start', Step1)])
-        response, instance = testform(request)
-
-        form_list = instance.get_form_list()
-        self.assertEqual(form_list, {'start': Step1})
-        with self.assertRaises(KeyError):
-            instance.get_form('step2')
-
-    def test_get_form_list_custom(self):
-        request = get_request()
-        testform = TestWizardWithCustomGetFormList.as_view([('start', Step1)])
-        response, instance = testform(request)
-
-        form_list = instance.get_form_list()
-        self.assertEqual(form_list, {'start': Step1, 'step2': Step2})
-        self.assertIsInstance(instance.get_form('step2'), Step2)
 
 
 class SessionFormTests(TestCase):


### PR DESCRIPTION
Please see #220, this is causing a lot of problems as a breaking change was accidentally introduced in 2.4.

It might be that there is a "better" fix in #221 or via another solution, but I think the priority should be to release 2.4.1 with this PR in and the original functionality fixed.

This would buy time to find a better solution that allows for the request of #168 to be implemented without causing the problems that the original change caused.

Thank you for this fantastic package.