### PR TITLE
 Add support for passing extra parameters to the form constructor (FormPreview)

### DIFF
--- a/formtools/preview.py
+++ b/formtools/preview.py
@@ -51,7 +51,8 @@ class FormPreview:
     def preview_get(self, request):
         "Displays the form"
         f = self.form(auto_id=self.get_auto_id(),
-                      initial=self.get_initial(request))
+                      initial=self.get_initial(request),
+                      **self.form_extra_params(request))
         return render(request, self.form_template, self.get_context(request, f))
 
     def preview_post(self, request):
@@ -61,7 +62,10 @@ class FormPreview:
         """
         # Even if files are not supported in preview, we still initialize files
         # to give a chance to process_preview to access files content.
-        f = self.form(data=request.POST, files=request.FILES, auto_id=self.get_auto_id())
+        f = self.form(data=request.POST,
+                      files=request.FILES,
+                      auto_id=self.get_auto_id(),
+                      **self.form_extra_params(request))
         context = self.get_context(request, f)
         if f.is_valid():
             self.process_preview(request, f, context)
@@ -79,7 +83,7 @@ class FormPreview:
         """
         Validates the POST data. If valid, calls done(). Else, redisplays form.
         """
-        form = self.form(request.POST, auto_id=self.get_auto_id())
+        form = self.form(request.POST, auto_id=self.get_auto_id(), **self.form_extra_params(request))
         if form.is_valid():
             if not self._check_security_hash(
                     request.POST.get(self.unused_name('hash'), ''),
@@ -157,6 +161,14 @@ class FormPreview:
         an invalid security hash.
         """
         return self.preview_post(request)
+
+    def form_extra_params(self, request):
+        """
+        Extra parameters to pass to the form constructor.
+        Returns a dictionary.
+        By default, returns an empty dictionary.
+        """
+        return {}
 
     # METHODS SUBCLASSES MUST OVERRIDE ########################################
 

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -7,6 +7,10 @@ class TestForm(forms.Form):
     bool1 = forms.BooleanField(required=False)
     date1 = forms.DateField(required=False)
 
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop('request', None)
+        super(TestForm, self).__init__(*args, **kwargs)
+
 
 class HashTestForm(forms.Form):
     name = forms.CharField()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -32,6 +32,9 @@ class TestFormPreview(preview.FormPreview):
     def get_initial(self, request):
         return {'field1': 'Works!'}
 
+    def form_extra_params(self, request):
+        return {'request': request}
+
     def done(self, request, cleaned_data):
         return http.HttpResponse(success_string)
 
@@ -64,7 +67,7 @@ class PreviewTests(TestCase):
 
     def test_unused_name(self):
         """
-        Verifies name mangling to get uniue field name.
+        Verifies name mangling to get unique field name.
         """
         self.assertEqual(self.preview.unused_name('field1'), 'field1__')
 


### PR DESCRIPTION
Hey there,

I'm writing to submit a pull request that improves the FormPreview view. 

I ran into an issue when trying to pass extra context to the form constructor. While it's common to pass the request object to a form instance in Django, doing so with the FormPreview view required me to override several methods, including `post_post`, `preview_post`, and `preview_get`. This made the code more complex and harder to maintain.

To address this problem, I propose adding a `form_extra_params(self, request)` method that allows users to pass extra data to their form if needed. This method takes the request object as an argument, and by default, it returns an empty dictionary. Users can override this method to provide additional context to the form constructor, without having to modify the view's core methods.

I believe that this solution simplifies the code and makes it more flexible for developers who need to handle custom validation logic. I hope that you will find this pull request useful and that you will consider merging it into the main branch.

Thank you for your time and for maintaining this great package!

Best regards,
Tobi

PS: I'm not entirely sure how to write a test for this feature, but I believe it's straightforward enough that testing may not be necessary. However, if you feel that testing is required, I would be more than happy to conduct research and update my code accordingly. Thanks.