### PR TITLE
Limit version range for isort to >=5.11.1, <6.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 coverage==4.5.4
 flake8
-isort
+isort>=5.11.1, <6.0


### PR DESCRIPTION
The actions fail because isort beta (6.0.0b2) is installed by default. Version 5.11.0 is missing the `colorama` dependency so therefore pinning the lower bounds to 5.11.1