### PR TITLE
Extend test matrix with django 4.2, python 3.11 and python 3.12-dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev']
 
     steps:
     - uses: actions/checkout@v3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 coverage==4.5.4
 flake8
-isort
+isort>=5.11.1, <6.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 args_are_paths = false
 envlist =
     py{37,38,39,310}-django32
-    py{38,39,310}-django{40,41,main}
+    py{38,39,310,311}-django{40,41,42}
+    py{310,311,312}-django{main}
 
 [testenv]
 usedevelop = true
@@ -13,12 +14,15 @@ deps =
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0
     djangomain: https://github.com/django/django/archive/main.tar.gz
     -r{toxinidir}/tests/requirements.txt
 ignore_outcome =
-    djmain: True
+    djangomain: True
+    py312: True
 ignore_errors =
-    djmain: True
+    djangomain: True
+    py312: True
 
 [gh-actions]
 python =
@@ -26,3 +30,5 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12-dev: py312


### PR DESCRIPTION
This PR extends the test matrix with the latest versions and removes testing for python 3.8 & 3.9 against main. 