### PR TITLE
Draft: restore original form list generation and support dynamic form lists Fixes #220

### DIFF
--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -165,8 +165,6 @@ class WizardView(TemplateView):
 
         computed_form_list = OrderedDict()
 
-        assert len(form_list) > 0, 'at least one form is needed'
-
         # walk through the passed form list
         for i, form in enumerate(form_list):
             if isinstance(form, (list, tuple)):
@@ -395,6 +393,17 @@ class WizardView(TemplateView):
         """
         return {}
 
+    def get_form_class(self, step):
+        """
+        Returns the form class for step.
+
+        If self.form_list is not empty then it is assumed the wizard has been
+        implemented according to the original form list generation strategy and the form
+        class is taken from there. If self.form_list is empty, however, then get the
+        form class from the dynamically generated list provided by get_form_list().
+        """
+        return self.form_list[step] if self.form_list else self.get_form_list()[step]
+
     def get_form(self, step=None, data=None, files=None):
         """
         Constructs the form for a given `step`. If no `step` is defined, the
@@ -406,7 +415,7 @@ class WizardView(TemplateView):
         """
         if step is None:
             step = self.steps.current
-        form_class = self.get_form_list()[step]
+        form_class = self.get_form_class(step)
         # prepare the kwargs for the form instance.
         kwargs = self.get_form_kwargs(step)
         kwargs.update({

--- a/tests/wizard/test_forms.py
+++ b/tests/wizard/test_forms.py
@@ -93,9 +93,6 @@ class TestWizardWithTypeCheck(TestWizard):
 
 
 class TestWizardWithCustomGetFormList(TestWizard):
-
-    form_list = [Step1]
-
     def get_form_list(self):
         return {'start': Step1, 'step2': Step2}
 
@@ -318,7 +315,7 @@ class FormTests(TestCase):
 
     def test_get_form_list_custom(self):
         request = get_request()
-        testform = TestWizardWithCustomGetFormList.as_view([('start', Step1)])
+        testform = TestWizardWithCustomGetFormList.as_view()
         response, instance = testform(request)
 
         form_list = instance.get_form_list()


### PR DESCRIPTION
This is an attempt to fix #220 while restoring pre-#209 features and supporting dynamic form lists using custom `get_form_list()` implementations. 

The solution has two parts:
1. New method `get_form_class()` uses `self.form_list` as a key to determine whether the class is implemented using the original form list generation strategy (ie, `form_list` and `condition_dict`) or the more dynamic approach (ie, overriding `get_form_list()`).  If `form_list` is populated, the strategy is inferred to be the original one. 
2. `get_cleaned_data_for_step()` now supports an optional form class argument so that `get_form()` doesn't need to call `get_form_list()` and trigger infinite recursion. This enables custom `get_form_list()` implementations to access submitted data from other steps.

Change 1 will be a breaking change for implementations that have a custom `get_form_list()` - the developers would need to stop passing any forms via `as_view()` or setting them in the class, and may need to modify `get_form_list()` to adapt for this.  Another option would be an explicit argument to `as_view()` that selects the form list generation strategy but `form_list` seems an adequate and natural key for this purpose. Change 1 ensure that the original form list generation strategy is not prone to infinite recursion.

re: change 2, there are probably some different and possibly better ways of handling this, but I think this way is okay and backwards compatible.  In the fully dynamic / custom `get_form_list()` approach, the form class for a given step is known only to `get_form_list()` so it must explicitly tell the other methods what form class to instantiate for each step.

I explored another option where the infinite recursion was broken by having `get_form_list()` return a partial cached form list. This allowed callables in `condition_dict` to access data from earlier steps.  This would replace change 1 but something like change 2 would still be required for custom `get_form_list()` methods. I liked this option because it introduced caching but it was more complicated and it broke a test that implied that changing `condition_dict` during request handling was supported. Not sure what the use case for that would be.

Anyway, hit me with your feedback.  Additional manual testing is needed. I have run the test suite but not tried it in any projects, so please try it out. It also needs docs updates.