### PR TITLE
Remove Python 3.7 support; switch from slow and deprecated pkg_resources to importlib.metadata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/formtools/__init__.py
+++ b/formtools/__init__.py
@@ -1,9 +1,10 @@
+from importlib.metadata import PackageNotFoundError, version
+
 import django
-from pkg_resources import DistributionNotFound, get_distribution
 
 try:
-    __version__ = get_distribution("django-formtools").version
-except DistributionNotFound:
+    __version__ = version("django-formtools")
+except PackageNotFoundError:
     # package is not installed
     __version__ = None
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
     install_requires=["Django>=3.2"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
@@ -40,7 +40,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,6 @@ ignore_errors =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
Python 3.7 reached end of life on June 27, 2023: https://devguide.python.org/versions/

Fixes this warning in Python [development mode](https://docs.python.org/3/library/devmode.html):

```
…/formtools/__init__.py:2: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  from pkg_resources import DistributionNotFound, get_distribution
```