### PR TITLE
PEP 621: Migrate from setup.py to pyproject.toml -- Part 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,15 +20,12 @@ repos:
     hooks:
       - id: ruff
 
-
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:
-      - id: codespell
+      - id: codespell  # See pyproject.toml for args
         additional_dependencies:
           - tomli
-        args:
-          [--skip, "*.po"]
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ zip-safe = false
 exclude = ["tests"] # tests.*
 namespaces = false
 
+[tool.codespell]
+skip = "*.po"
+
 [tool.isort]
 combine_as_imports = true
 default_section = "THIRDPARTY"
@@ -63,3 +66,12 @@ include_trailing_comma = true
 known_first_party = ["formtools"]
 line_length = 79
 multi_line_output = 5
+
+[tool.ruff]
+ignore = ["PLW2901", "UP031", "UP032"]
+line-length = 119
+select = ["ASYNC", "C4", "C90", "DJ", "E", "F", "PL", "UP", "W"]
+
+[tool.ruff.per-file-ignores]
+"tests/wizard/test_forms.py" = ["DJ007", "DJ008"]
+"tests/wizard/wizardtests/tests.py" = ["DJ007"]


### PR DESCRIPTION
### How
Migrate `setup.py` to `setup.cfg` using [setuptools-py2cfg](https://pypi.org/project/setuptools-py2cfg) plus manual modifications.  Use [setup-cfg-fmt](https://pypi.org/project/setup-cfg-fmt) to format the results.

Migrate settings from `setup.cfg` into `pyproject.toml` using [ini2toml](https://pypi.org/project/ini2toml) to do the file conversion and running [pyproject-fmt](https://pypi.org/project/pyproject-fmt) and then [validate-pyproject](https://github.com/abravalheri/validate-pyproject) in pre-commit to validate the results.

Flake8 _still_ does not support the use `pyproject.toml` so its configuration was moved to a `.flake8` file.

### Why
https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use
> We recommend users expose as much as possible configuration in a more declarative way via the [pyproject.toml](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html) or [setup.cfg](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html), and keep the setup.py minimal with only the dynamic parts (or even omit it completely if applicable).

From `validate-pyproject` README:
> With the approval of [PEP 517](https://www.python.org/dev/peps/pep-0517/) and [PEP 518](https://www.python.org/dev/peps/pep-0518/), the Python community shifted towards a strong focus on standardization for packaging software, which allows more freedom when choosing tools during development and make sure packages created using different technologies can interoperate without the need for custom installation procedures.

> This shift became even more clear when [PEP 621](https://www.python.org/dev/peps/pep-0621/) was also approved, as a standardized way of specifying project metadata and dependencies.

> `validate-pyproject` was born in this context, with the mission of validating `pyproject.toml` files, and making sure they are compliant with the standards and PEPs.