### PR TITLE
Remove invalid combinations from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
 args_are_paths = false
 envlist =
-    py{38,39,310,311}-django32
-    py{38,39,310,311}-django{40,41,42}
+    py{38,39,310}-django32
+    py{38,39,310}-django40
+    py{38,39,310,311}-django41
+    py{38,39,310,311}-django42
     py{310,311,312}-django50
     py{310,311,312}-djangomain
 


### PR DESCRIPTION
Follow-up to #248, removing Python 3.11 from Django 3.2 and 4.0, since they don't support it.