### PR TITLE
Better example HTML in docs for previous/first buttons

### DIFF
--- a/docs/wizard.rst
+++ b/docs/wizard.rst
@@ -226,8 +226,8 @@ Here's a full example template:
     {% endif %}
     </table>
     {% if wizard.steps.prev %}
-    <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}">{% translate "first step" %}</button>
-    <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% translate "prev step" %}</button>
+    <button name="wizard_goto_step" type="submit" formnovalidate value="{{ wizard.steps.first }}">{% translate "first step" %}</button>
+    <button name="wizard_goto_step" type="submit" formnovalidate value="{{ wizard.steps.prev }}">{% translate "prev step" %}</button>
     {% endif %}
     <input type="submit" value="{% translate "submit" %}"/>
     </form>


### PR DESCRIPTION
When going to a previous form, we don't want the user to get stuck on an invalid form. The `formnovalidate` attribute is what we need. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/submit#formnovalidate