### PR TITLE
Add ruff rules for naming, performance, simplification, and timezones

### DIFF
--- a/formtools/utils.py
+++ b/formtools/utils.py
@@ -12,7 +12,7 @@ def form_hmac(form):
     for bf in form:
         # Get the value from the form data. If the form allows empty or hasn't
         # changed then don't call clean() to avoid trigger validation errors.
-        if form.empty_permitted and not form.has_changed():
+        if form.empty_permitted and not form.has_changed():  # noqa: SIM108
             value = bf.data or ''
         else:
             value = bf.field.clean(bf.data) or ''

--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -658,10 +658,7 @@ class NamedUrlWizardView(WizardView):
             if 'reset' in self.request.GET:
                 self.storage.reset()
                 self.storage.current_step = self.steps.first
-            if self.request.GET:
-                query_string = "?%s" % self.request.GET.urlencode()
-            else:
-                query_string = ""
+            query_string = '?%s' % self.request.GET.urlencode() if self.request.GET else ''
             return redirect(self.get_step_url(self.steps.current) + query_string)
 
         # is the current step the "done" name/view?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,12 @@ line_length = 79
 multi_line_output = 5
 
 [tool.ruff]
-ignore = ["PLW2901"]
 line-length = 119
-select = ["ASYNC", "C4", "C90", "DJ", "E", "F", "PL", "UP", "W"]
+select = ["ASYNC", "C4", "C90", "DJ", "DTZ", "E", "F", "N", "PERF", "PL", "SIM", "UP", "W"]
 
 [tool.ruff.per-file-ignores]
-"tests/wizard/test_forms.py" = ["DJ007", "DJ008"]
+"formtools/wizard/storage/base.py" = ["PLW2901"]
+"formtools/wizard/views.py" = ["N805", "PLW2901"]
+"tests/wizard/storage.py" = ["DTZ005"]
+"tests/wizard/test_forms.py" = ["DJ007", "DJ008", "N803"]
 "tests/wizard/wizardtests/tests.py" = ["DJ007"]

--- a/tests/wizard/namedwizardtests/forms.py
+++ b/tests/wizard/namedwizardtests/forms.py
@@ -43,7 +43,7 @@ class ContactWizard(NamedUrlWizardView):
             'all_cleaned_data': self.get_all_cleaned_data()
         })
 
-        for form in self.form_list.keys():
+        for form in self.form_list:
             c[form] = self.get_cleaned_data_for_step(form)
 
         c['this_will_fail'] = self.get_cleaned_data_for_step('this_will_fail')

--- a/tests/wizard/wizardtests/forms.py
+++ b/tests/wizard/wizardtests/forms.py
@@ -43,7 +43,7 @@ class ContactWizard(WizardView):
             'all_cleaned_data': self.get_all_cleaned_data(),
         })
 
-        for form in self.form_list.keys():
+        for form in self.form_list:
             c[form] = self.get_cleaned_data_for_step(form)
 
         c['this_will_fail'] = self.get_cleaned_data_for_step('this_will_fail')


### PR DESCRIPTION
Add [ruff rules](https://docs.astral.sh/ruff/rules/) for [naming](https://docs.astral.sh/ruff/rules/#pep8-naming-n), [performance](https://docs.astral.sh/ruff/rules/#perflint-perf), [simplification](https://docs.astral.sh/ruff/rules/#flake8-simplify-sim), and [timezones](https://docs.astral.sh/ruff/rules/#flake8-datetimez-dtz).