### PR TITLE
Fix form validation in default templates

### DIFF
--- a/formtools/templates/formtools/wizard/wizard_form.html
+++ b/formtools/templates/formtools/wizard/wizard_form.html
@@ -13,8 +13,8 @@
 {% endif %}
 
 {% if wizard.steps.prev %}
-<button name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}">{% translate "first step" %}</button>
-<button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% translate "prev step" %}</button>
+<button name="wizard_goto_step" type="submit" formnovalidate value="{{ wizard.steps.first }}">{% translate "first step" %}</button>
+<button name="wizard_goto_step" type="submit" formnovalidate value="{{ wizard.steps.prev }}">{% translate "prev step" %}</button>
 {% endif %}
 <input type="submit" name="submit" value="{% translate "submit" %}" />
 </form>


### PR DESCRIPTION
The doc is already mentioning this fix (it's not published, unfortunately), but the default templates are not including it.

Fix https://github.com/jazzband/django-formtools/issues/198 in default templates