### PR TITLE
Exclude all tests from wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ license-files = ["LICENSE"]
 zip-safe = false
 
 [tool.setuptools.packages.find]
-exclude = ["tests"] # tests.*
+exclude = ["tests*"]
 namespaces = false
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Previously, the "tests/wizard" package was still included in the built wheel, because the tool.setuptools.packages.find.exclude directive matches each fully qualified package name separately:

```
django-formtools $ unzip -l dist/*
Archive:  dist/django_formtools-2.5.1-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
      299  2024-03-24 13:32   formtools/__init__.py
      183  2024-03-24 13:32   formtools/apps.py
      103  2024-03-24 13:32   formtools/models.py
     6251  2024-03-24 13:32   formtools/preview.py
      938  2024-03-24 13:32   formtools/utils.py
[snip locales]
      435  2024-03-24 13:32   formtools/templates/formtools/form.html
      906  2024-03-24 13:32   formtools/templates/formtools/preview.html
      684  2024-03-24 13:32   formtools/templates/formtools/wizard/wizard_form.html
        0  2024-03-24 13:32   formtools/wizard/__init__.py
      299  2024-03-24 13:32   formtools/wizard/forms.py
    29126  2024-03-24 13:32   formtools/wizard/views.py
      471  2024-03-24 13:32   formtools/wizard/storage/__init__.py
     4998  2024-03-24 13:32   formtools/wizard/storage/base.py
      806  2024-03-24 13:32   formtools/wizard/storage/cookie.py
      175  2024-03-24 13:32   formtools/wizard/storage/exceptions.py
      523  2024-03-24 13:32   formtools/wizard/storage/session.py
        0  2024-03-24 13:32   tests/wizard/__init__.py
     3660  2024-03-24 13:32   tests/wizard/storage.py
      577  2024-03-24 13:32   tests/wizard/test_basestorage.py
     1640  2024-03-24 13:32   tests/wizard/test_cookiestorage.py
    11852  2024-03-24 13:32   tests/wizard/test_forms.py
      678  2024-03-24 13:32   tests/wizard/test_loadstorage.py
      236  2024-03-24 13:32   tests/wizard/test_sessionstorage.py
        0  2024-03-24 13:32   tests/wizard/namedwizardtests/__init__.py
     1708  2024-03-24 13:32   tests/wizard/namedwizardtests/forms.py
    16243  2024-03-24 13:32   tests/wizard/namedwizardtests/tests.py
      978  2024-03-24 13:32   tests/wizard/namedwizardtests/urls.py
        0  2024-03-24 13:32   tests/wizard/wizardtests/__init__.py
     2095  2024-03-24 13:32   tests/wizard/wizardtests/forms.py
      430  2024-03-24 13:32   tests/wizard/wizardtests/models.py
    19183  2024-03-24 13:32   tests/wizard/wizardtests/tests.py
      697  2024-03-24 13:32   tests/wizard/wizardtests/urls.py
       50  2024-03-24 13:32   tests/wizard/wizardtests/templates/other_wizard_form.html
     1562  2024-03-24 14:24   django_formtools-2.5.1.dist-info/LICENSE
     3689  2024-03-24 14:24   django_formtools-2.5.1.dist-info/METADATA
       92  2024-03-24 14:24   django_formtools-2.5.1.dist-info/WHEEL
       16  2024-03-24 14:24   django_formtools-2.5.1.dist-info/top_level.txt
    17509  2024-03-24 14:24   django_formtools-2.5.1.dist-info/RECORD
---------                     -------
   337147                     182 files
```

This PR fixes this by using a glob to exclude all test packages.

Note that the wheel for 2.5.1 on PyPI also contains the `tests/wizard` directory, while the one for 2.4.1 does not.