### PR TITLE
Fix documentation build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -317,7 +317,7 @@ epub_copyright = '2014, Django Software Foundation and individual contributors'
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'http://docs.python.org/': None,
+    'python': ('https://docs.python.org/3', None),
     'django': ('http://docs.djangoproject.com/en/dev/',
                'http://docs.djangoproject.com/en/dev/_objects/'),
 }


### PR DESCRIPTION
The intersphinx_mapping format now requires a tuple [1].

Fixes #279

[1] - https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration