### PR TITLE
Updated Python/Django supported versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,11 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13'
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,28 +15,26 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
   "Framework :: Django",
-  "Framework :: Django :: 3.2",
-  "Framework :: Django :: 4.0",
-  "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",
+  "Framework :: Django :: 5.1",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Internet :: WWW/HTTP",
 ]
 dynamic = [
   "version",
 ]
 dependencies = [
-  "Django>=3.2",
+  "Django>=4.2",
 ]
 
 [project.readme]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
 args_are_paths = false
 envlist =
-    py{38,39,310}-django32
-    py{38,39,310}-django40
-    py{38,39,310,311}-django41
-    py{38,39,310,311}-django42
+    py{39,310,311,312}-django42
     py{310,311,312}-django50
-    py{310,311,312}-djangomain
+    py{310,311,312,313}-django51
+    py{312,313}-djangomain
 
 [testenv]
 usedevelop = true
@@ -14,11 +12,9 @@ allowlist_externals = make
 commands = make test
 pip_pre = true
 deps =
-    django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<5.0
-    django50: Django>=5.0a1,<5.1
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
     djangomain: https://github.com/django/django/archive/main.tar.gz
     -r{toxinidir}/tests/requirements.txt
 ignore_outcome =
@@ -28,8 +24,8 @@ ignore_errors =
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313


### PR DESCRIPTION
Drop Python 3.8, add Python 3.13
Drop Django < 4.2, add Django 5.1