### PR TITLE
docs: document reset feature

### DIFF
--- a/docs/wizard.rst
+++ b/docs/wizard.rst
@@ -331,6 +331,14 @@ the name of the current step.
 
 .. _wizardview-advanced-methods:
 
+Manually resetting a form
+-------------------------
+Sometimes you might want to manually clear the saved form data for a particular session
+of a wizard. You can do this by passing the ``reset`` parameter in the form url, e.g.
+``https://[...]formtools-url?reset`` .
+Note: for ``NamedUrlWizardView`` this only works for the base url and not any of the
+`step` urls.
+
 Advanced ``WizardView`` methods
 ===============================
 


### PR DESCRIPTION
Adds documentation for the reset feature 

```python
step_url = kwargs.get('step', None)
if step_url is None:
    if 'reset' in self.request.GET:
        self.storage.reset()
        self.storage.current_step = self.steps.first
    query_string = '?%s' % self.request.GET.urlencode() if self.request.GET else ''
    return redirect(self.get_step_url(self.steps.current) + query_string)
```