### PR TITLE
Fixed an issue that occurred when the storage is a database

### DIFF
--- a/formtools/wizard/storage/base.py
+++ b/formtools/wizard/storage/base.py
@@ -36,10 +36,13 @@ class BaseStorage:
         self.init_data()
 
     def _get_current_step(self):
-        return self.data[self.step_key]
+        data = self.data
+        return data[self.step_key]
 
     def _set_current_step(self, step):
-        self.data[self.step_key] = step
+        data = self.data
+        data[self.step_key] = step
+        self.data = data
 
     @property
     def current_step(self):
@@ -66,7 +69,9 @@ class BaseStorage:
     def get_step_data(self, step):
         # When reading the serialized data, upconvert it to a MultiValueDict,
         # some serializers (json) don't preserve the type of the object.
-        values = self.data[self.step_data_key].get(step, None)
+        data = self.data[self.step_data_key].get(step)
+        
+        values = data
         if values is not None:
             values = MultiValueDict(values)
         return values
@@ -78,7 +83,9 @@ class BaseStorage:
         # can be truncated (__getitem__ returns only the first item).
         if isinstance(cleaned_data, MultiValueDict):
             cleaned_data = dict(cleaned_data.lists())
-        self.data[self.step_data_key][step] = cleaned_data
+        data = self.data 
+        data[self.step_data_key][step] = cleaned_data
+        self.data = data
 
     @property
     def current_step_data(self):


### PR DESCRIPTION
Using a custom storage like the following Python does not call the setter method, not saving anything inside the database 

```python
class DbStorage(BaseStorage):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        session = self.get_session()
        if not WizardStep.objects.filter(session=session).exists():
            self.init_data()

    def get_session(self): 
        return Session.objects.get(session_key=self.request.session.session_key)

    def get_db_safe(self) -> OnboardingWizardStep:
        defaults = {"payload": {'step': None, 'step_data': {}, 'step_files': {}, 'extra_data': {}}}
        s, _ = WizardStep.objects.get_or_create(session=self.get_session(), defaults=defaults)
        return s

    @property
    def data(self):
        return self.get_db_safe().payload

    @data.setter
    def data(self, value):
        s = self.get_db_safe()
        s.payload = value
        s.save()
```

The following two functions inside `wizard/storage/base.py` without a temporary value do not allow for saving
```python
    def _get_current_step(self):
        return self.data[self.step_key]

    def _set_current_step(self, step):
        self.data[self.step_key] = step
```