### PR TITLE
Improve performance when using condition_dict

### DIFF
--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -217,9 +217,9 @@ class WizardView(TemplateView):
             id(self.condition_dict),
             tuple(sorted(self.condition_dict.items())),
         )
-        if (getattr(self, '_resolved_form_list', None) and
+        if (hasattr(self, '_resolved_form_list') and
             self._condition_dict_signature == condition_dict_signature):
-            return self._resolved_form_list
+            return self._resolved_form_list.copy()
 
         form_list = OrderedDict()
         if getattr(self, '_check_cond_started', False):

--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -217,7 +217,7 @@ class WizardView(TemplateView):
             id(self.condition_dict),
             tuple(sorted(self.condition_dict.items())),
         )
-        if (hasattr(self, '_resolved_form_list') and
+        if (getattr(self, '_resolved_form_list', None) and
             self._condition_dict_signature == condition_dict_signature):
             return self._resolved_form_list
 

--- a/formtools/wizard/views.py
+++ b/formtools/wizard/views.py
@@ -209,9 +209,18 @@ class WizardView(TemplateView):
         and respect the result. (True means add the form, False means ignore
         the form)
 
-        The form_list is always generated on the fly because condition methods
-        could use data from other (maybe previous forms).
+        The form_list is generated once per wizard instance to avoid repeated
+        expensive condition evaluations (e.g., database queries).
         """
+        # Check if condition_dict has been modified since last resolution
+        condition_dict_signature = (
+            id(self.condition_dict),
+            tuple(sorted(self.condition_dict.items())),
+        )
+        if (hasattr(self, '_resolved_form_list') and
+            self._condition_dict_signature == condition_dict_signature):
+            return self._resolved_form_list
+
         form_list = OrderedDict()
         if getattr(self, '_check_cond_started', False):
             # Guard against infinite recursion, in the case a get_form_list is
@@ -228,6 +237,8 @@ class WizardView(TemplateView):
             if condition:
                 form_list[form_key] = form_class
         del self._check_cond_started
+        self._resolved_form_list = form_list
+        self._condition_dict_signature = condition_dict_signature
         return form_list
 
     def dispatch(self, request, *args, **kwargs):
@@ -301,6 +312,12 @@ class WizardView(TemplateView):
             # if the form is valid, store the cleaned data and files.
             self.storage.set_step_data(self.steps.current, self.process_step(form))
             self.storage.set_step_files(self.steps.current, self.process_step_files(form))
+            # Clear caches as changed step data could affect conditions
+            del self._resolved_form_list
+            del self._condition_dict_signature
+            for attr_name in list(self.__dict__.keys()):
+                if attr_name.startswith('_cleaned_data_cache_'):
+                    delattr(self, attr_name)
 
             # check if the current step is the last step
             if self.steps.current == self.steps.last:
@@ -497,13 +514,20 @@ class WizardView(TemplateView):
         If the data doesn't validate, None will be returned.
         """
         if step in self.form_list:
+            cache_key = f'_cleaned_data_cache_{step}'
+            if cached_data := getattr(self, cache_key, None):
+                return cached_data
             form_obj = self.get_form(
                 step=step,
                 data=self.storage.get_step_data(step),
                 files=self.storage.get_step_files(step),
             )
             if form_obj.is_valid():
-                return form_obj.cleaned_data
+                cleaned_data = form_obj.cleaned_data
+                setattr(self, cache_key, cleaned_data)
+                return cleaned_data
+            else:
+                setattr(self, cache_key, None)
         return None
 
     def get_next_step(self, step=None):

--- a/tests/wizard/test_forms.py
+++ b/tests/wizard/test_forms.py
@@ -192,13 +192,20 @@ class FormTests(TestCase):
                 self.initial_call_count += 1
                 return super().get_form_initial(step)
 
-        testform = TestWizardWithTracking.as_view([('start', Step1), ('step2', Step2)])
-        request = get_request({'test_wizard_with_tracking-current_step': 'start', 'start-name': 'test'})
+        testform = TestWizardWithTracking.as_view(
+            [('start', Step1), ('step2', Step2)]
+        )
+        request = get_request(
+            {
+                'test_wizard_with_tracking-current_step': 'start',
+                'start-name': 'test'
+            }
+        )
 
         response, instance = testform(request)
         calls_during_submission = instance.initial_call_count
 
-        self.assertLessEqual(calls_during_submission, 4, f"Form submission with condition using get_cleaned_data_for_step should not cause excessive get_form_initial calls, got {calls_during_submission}")
+        self.assertLessEqual(calls_during_submission, 4)
 
     def test_form_condition_unstable(self):
         request = get_request()

--- a/tests/wizard/test_forms.py
+++ b/tests/wizard/test_forms.py
@@ -217,6 +217,27 @@ class FormTests(TestCase):
         instance.steps.first
         self.assertEqual(instance.get_form_list(), OrderedDict([('start', Step1)]))
 
+    def test_cleaned_data_caching(self):
+        class TrackedStep1(Step1):
+            instantiation_count = 0
+
+            def __init__(self, *args, **kwargs):
+                TrackedStep1.instantiation_count += 1
+                super().__init__(*args, **kwargs)
+
+        testform = TestWizard.as_view([('start', TrackedStep1), ('step2', Step2)])
+        request = get_request({
+            'test_wizard-current_step': 'start',
+            'start-name': 'test'
+        })
+        response, instance = testform(request)
+        TrackedStep1.instantiation_count = 0
+        cleaned_data_1 = instance.get_cleaned_data_for_step('start')
+        cleaned_data_2 = instance.get_cleaned_data_for_step('start')
+        self.assertEqual(TrackedStep1.instantiation_count, 1)
+        self.assertEqual(cleaned_data_1, cleaned_data_2)
+        self.assertTrue(hasattr(instance, '_cleaned_data_cache_start'))
+
     def test_form_condition_unstable(self):
         request = get_request()
         testform = TestWizard.as_view(

--- a/tests/wizard/test_forms.py
+++ b/tests/wizard/test_forms.py
@@ -179,6 +179,27 @@ class FormTests(TestCase):
         finally:
             sys.setrecursionlimit(old_limit)
 
+    def test_form_initial_multiple_calls_regression(self):
+        def step2_condition(wizard):
+            wizard.get_cleaned_data_for_step('start')
+            return True
+
+        class TestWizardWithTracking(TestWizard):
+            condition_dict = {'step2': step2_condition}
+            initial_call_count = 0
+
+            def get_form_initial(self, step):
+                self.initial_call_count += 1
+                return super().get_form_initial(step)
+
+        testform = TestWizardWithTracking.as_view([('start', Step1), ('step2', Step2)])
+        request = get_request({'test_wizard_with_tracking-current_step': 'start', 'start-name': 'test'})
+
+        response, instance = testform(request)
+        calls_during_submission = instance.initial_call_count
+
+        self.assertLessEqual(calls_during_submission, 4, f"Form submission with condition using get_cleaned_data_for_step should not cause excessive get_form_initial calls, got {calls_during_submission}")
+
     def test_form_condition_unstable(self):
         request = get_request()
         testform = TestWizard.as_view(

--- a/tests/wizard/test_forms.py
+++ b/tests/wizard/test_forms.py
@@ -1,4 +1,5 @@
 import sys
+from collections import OrderedDict
 from importlib import import_module
 
 from django import forms, http
@@ -204,6 +205,17 @@ class FormTests(TestCase):
         response, instance = testform(request)
         calls_during_submission = instance.initial_call_count
         self.assertLessEqual(calls_during_submission, 4)
+
+    def test_form_list_pop_regression(self):
+        request = get_request()
+        testform = TestWizard.as_view([('start', Step1)])
+        response, instance = testform(request)
+        form_list = instance.get_form_list()
+        self.assertEqual(form_list, OrderedDict([('start', Step1)]))
+        form_list.pop('start')
+        # This will raise IndexError with an empty cached form_list.
+        instance.steps.first
+        self.assertEqual(instance.get_form_list(), OrderedDict([('start', Step1)]))
 
     def test_form_condition_unstable(self):
         request = get_request()

--- a/tests/wizard/test_forms.py
+++ b/tests/wizard/test_forms.py
@@ -201,10 +201,8 @@ class FormTests(TestCase):
                 'start-name': 'test'
             }
         )
-
         response, instance = testform(request)
         calls_during_submission = instance.initial_call_count
-
         self.assertLessEqual(calls_during_submission, 4)
 
     def test_form_condition_unstable(self):


### PR DESCRIPTION
Fixes #134 

Uses a bit of caching to reduce the number of calls needed when using condition_dict.

For us, this reduces the number of queries in one view (for each step of that view) from nearly 300 to around 17. It's possible it could be improved further but I think this is a dramatic enough of an improvement to be useful on its own.

All the tests pass and I checked my wizards were all working locally. I went for a slightly more realistic test rather than a minimal test, but I can change this if desired.

A simpler solution is to cache the `all` property. It works quite well, but there are still some extra queries when doing this.